### PR TITLE
Backport to Go 1.16

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/FlashpointProject/FlashpointGameServer
 
-go 1.18
+go 1.16
 
 require (
 	github.com/FlashpointProject/zipfs v0.0.0-20231103125305-60ba85d03bce

--- a/main.go
+++ b/main.go
@@ -383,5 +383,5 @@ XgVWIMrKj4T7p86bcxq4jdWDYUYpRd/2Og==
 	}()
 
 	// Start proxy server
-	log.Fatal(http.ListenAndServe("127.0.0.1:"+serverSettings.ProxyPort, http.AllowQuerySemicolons(proxy)))
+	log.Fatal(http.ListenAndServe("127.0.0.1:"+serverSettings.ProxyPort, proxy))
 }


### PR DESCRIPTION
Removed http.AllowQuerySemicolons from the main code, as it is unnecessary in 99.9% of cases. If a semicolon is needed in a download URL for whatever reason, %3B should be used in its place. Confirmed working for launch commands with semicolons in them, on both standalone projectors and browser plugins.